### PR TITLE
Adds dafni_internal_properties to schema

### DIFF
--- a/metadata_schema_for_upload.json
+++ b/metadata_schema_for_upload.json
@@ -1907,6 +1907,36 @@
         "dafni_version_note": {
             "type": "string",
             "minLength": 1
+        },
+        "dafni_internal_properties": {
+            "type": "object",
+            "properties": {
+                "storage_location": {
+                    "type": "string",
+                    "enum": [
+                        "S3",
+                        "NFS"
+                    ]
+                },
+                "nfs_path": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "storage_location"
+            ],
+            "if": {
+                "properties": {
+                    "storage_location": {
+                        "const": "NFS"
+                    }
+                }
+            },
+            "then": {
+                "required": [
+                    "nfs_path"
+                ]
+            }
         }
     }
 }


### PR DESCRIPTION
This new field adds the storage location of data, and if not the standard S3 (i.e. NFS) a path to where the data is stored